### PR TITLE
Added RequiresUnreferencedCode on non-trimmable code

### DIFF
--- a/src/Ben.Demystifier/Constants.cs
+++ b/src/Ben.Demystifier/Constants.cs
@@ -1,0 +1,7 @@
+namespace Ben.Demystifier;
+
+internal static class Constants
+{
+    internal const string TrimWarning = "This class should be avoided when compiling for AOT.";
+    internal const string SuppressionResurfaced = "Surfaced by parent class";
+}

--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -6,6 +6,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Generic.Enumerable;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Internal;
 using System.Linq;
 using System.Reflection;
@@ -14,9 +15,13 @@ using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public partial class EnhancedStackTrace
     {
         private static readonly Type? StackTraceHiddenAttributeType = Type.GetType("System.Diagnostics.StackTraceHiddenAttribute", false);

--- a/src/Ben.Demystifier/ExceptionExtensions.cs
+++ b/src/Ben.Demystifier/ExceptionExtensions.cs
@@ -3,8 +3,10 @@
 
 using System.Collections.Generic;
 using System.Collections.Generic.Enumerable;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
+using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
@@ -18,6 +20,9 @@ namespace System.Diagnostics
         /// <summary>
         /// Demystifies the given <paramref name="exception"/> and tracks the original stack traces for the whole exception tree.
         /// </summary>
+        #if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = Constants.SuppressionResurfaced)]
+        #endif
         public static T Demystify<T>(this T exception) where T : Exception
         {
             try
@@ -57,6 +62,9 @@ namespace System.Diagnostics
         /// computes a demystified string representation and then restores the original state of the exception back.
         /// </remarks>
         [Contracts.Pure]
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public static string ToStringDemystified(this Exception exception) 
             => new StringBuilder().AppendDemystified(exception).ToString();
     }

--- a/src/Ben.Demystifier/Internal/ILReader.cs
+++ b/src/Ben.Demystifier/Internal/ILReader.cs
@@ -1,8 +1,13 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.Emit;
+using Ben.Demystifier;
 
 namespace System.Diagnostics.Internal
 {
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     internal class ILReader
     {
         private static OpCode[] singleByteOpCode;

--- a/src/Ben.Demystifier/Internal/PortablePdbReader.cs
+++ b/src/Ben.Demystifier/Internal/PortablePdbReader.cs
@@ -2,20 +2,28 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using Ben.Demystifier;
 
 namespace System.Diagnostics.Internal
 {
     // Adapted from https://github.com/aspnet/Common/blob/dev/shared/Microsoft.Extensions.StackTrace.Sources/StackFrame/PortablePdbReader.cs
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     internal class PortablePdbReader : IDisposable
     {
         private readonly Dictionary<string, MetadataReaderProvider> _cache =
             new Dictionary<string, MetadataReaderProvider>(StringComparer.Ordinal);
 
+        #if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = Constants.SuppressionResurfaced)]
+        #endif
         public void PopulateStackFrame(StackFrame frameInfo, MethodBase method, int IlOffset, out string fileName, out int row, out int column)
         {
             fileName = "";

--- a/src/Ben.Demystifier/Internal/PortablePdbReader.cs
+++ b/src/Ben.Demystifier/Internal/PortablePdbReader.cs
@@ -21,9 +21,9 @@ namespace System.Diagnostics.Internal
         private readonly Dictionary<string, MetadataReaderProvider> _cache =
             new Dictionary<string, MetadataReaderProvider>(StringComparer.Ordinal);
 
-        #if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
         [UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = Constants.SuppressionResurfaced)]
-        #endif
+#endif
         public void PopulateStackFrame(StackFrame frameInfo, MethodBase method, int IlOffset, out string fileName, out int row, out int column)
         {
             fileName = "";

--- a/src/Ben.Demystifier/Internal/ReflectionHelper.cs
+++ b/src/Ben.Demystifier/Internal/ReflectionHelper.cs
@@ -2,14 +2,19 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Threading;
+using Ben.Demystifier;
 
 namespace System.Diagnostics.Internal
 {
     /// <summary>
     /// A helper class that contains utilities methods for dealing with reflection.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public static class ReflectionHelper
     {
         private static PropertyInfo? transformerNamesLazyPropertyInfo;

--- a/src/Ben.Demystifier/ResolvedMethod.cs
+++ b/src/Ben.Demystifier/ResolvedMethod.cs
@@ -2,11 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic.Enumerable;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
+using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public class ResolvedMethod
     {
         public MethodBase? MethodBase { get; set; }

--- a/src/Ben.Demystifier/ResolvedParameter.cs
+++ b/src/Ben.Demystifier/ResolvedParameter.cs
@@ -1,10 +1,18 @@
 // Copyright (c) Ben A Adams. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using Ben.Demystifier;
 
 namespace System.Diagnostics
+
 {
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public class ResolvedParameter
     {
         public string? Name { get; set; }
@@ -18,6 +26,9 @@ namespace System.Diagnostics
 
         public override string ToString() => Append(new StringBuilder()).ToString();
 
+#if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
+#endif
         public StringBuilder Append(StringBuilder sb)
         {
             if (ResolvedType.Assembly.ManifestModule.Name == "FSharp.Core.dll" && ResolvedType.Name == "Unit")

--- a/src/Ben.Demystifier/StringBuilderExtentions.cs
+++ b/src/Ben.Demystifier/StringBuilderExtentions.cs
@@ -2,10 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic.Enumerable;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using Ben.Demystifier;
 
 namespace System.Diagnostics 
 {
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public static class StringBuilderExtentions
     {
         public static StringBuilder AppendDemystified(this StringBuilder builder, Exception exception)

--- a/src/Ben.Demystifier/TypeNameHelper.cs
+++ b/src/Ben.Demystifier/TypeNameHelper.cs
@@ -2,11 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
     // Adapted from https://github.com/aspnet/Common/blob/dev/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public static class TypeNameHelper
     {
         public static readonly Dictionary<Type, string> BuiltInTypeNames = new Dictionary<Type, string>
@@ -73,6 +78,9 @@ namespace System.Diagnostics
             return (genericPartIndex >= 0) ? type.Name.Substring(0, genericPartIndex) : type.Name;
         }
 
+        #if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
+        #endif
         private static void ProcessType(StringBuilder builder, Type type, DisplayNameOptions options)
         {
             if (type.IsGenericType)
@@ -145,6 +153,9 @@ namespace System.Diagnostics
             }
         }
 
+        #if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
+        #endif
         private static void ProcessGenericType(StringBuilder builder, Type type, Type[] genericArguments, int length, DisplayNameOptions options)
         {
             var offset = 0;

--- a/src/Ben.Demystifier/TypeNameHelper.cs
+++ b/src/Ben.Demystifier/TypeNameHelper.cs
@@ -78,9 +78,9 @@ namespace System.Diagnostics
             return (genericPartIndex >= 0) ? type.Name.Substring(0, genericPartIndex) : type.Name;
         }
 
-        #if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
         [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
-        #endif
+#endif
         private static void ProcessType(StringBuilder builder, Type type, DisplayNameOptions options)
         {
             if (type.IsGenericType)
@@ -153,9 +153,9 @@ namespace System.Diagnostics
             }
         }
 
-        #if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
         [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
-        #endif
+#endif
         private static void ProcessGenericType(StringBuilder builder, Type type, Type[] genericArguments, int length, DisplayNameOptions options)
         {
             var offset = 0;

--- a/src/Ben.Demystifier/ValueTupleResolvedParameter.cs
+++ b/src/Ben.Demystifier/ValueTupleResolvedParameter.cs
@@ -2,11 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Internal;
 using System.Text;
+using Ben.Demystifier;
 
 namespace System.Diagnostics 
 {
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public class ValueTupleResolvedParameter : ResolvedParameter
     {
         public IList<string> TupleNames { get; }


### PR DESCRIPTION
A lot of the methods in Ben.Demystifier make use of reflection and various other things that don't work with Trimming and AOT compilation. These methods have been decorated with [RequiresUnreferencedCode attributes](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/fixing-warnings#requiresunreferencedcode) so that code making use of these can suppress the warnings where appropriate (in the .NET SDK for Sentry, for example, we can [avoid calling these methods at runtime](https://github.com/getsentry/sentry-dotnet/blob/1f31a657f094f25d452dc2a04da10fa245c88042/src/Sentry/Internal/Extensions/JsonExtensions.cs#L552C1-L567C6) and then supress the warnings). 