### PR TITLE
Added RequiresUnreferencedCode to  EnhancedStackFrame.cs

### DIFF
--- a/src/Ben.Demystifier/EnhancedStackFrame.cs
+++ b/src/Ben.Demystifier/EnhancedStackFrame.cs
@@ -1,10 +1,15 @@
 ﻿// Copyright (c) Ben A Adams. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public class EnhancedStackFrame : StackFrame
     {
         private readonly string? _fileName;


### PR DESCRIPTION
An additional `RequiresUnreferencedCode` attribute required for us to be able to use Ben.Demystifier with `IsAotCompatible` enabled in the Sentry .NET SDK. 
