### PR TITLE
Disable file system analyzer warning

### DIFF
--- a/src/Ben.Demystifier/Internal/PortablePdbReader.cs
+++ b/src/Ben.Demystifier/Internal/PortablePdbReader.cs
@@ -15,7 +15,9 @@ namespace System.Diagnostics.Internal
     // Adapted from https://github.com/aspnet/Common/blob/dev/shared/Microsoft.Extensions.StackTrace.Sources/StackFrame/PortablePdbReader.cs
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
-#endif
+#endif 
+    // Allow direct file system usage
+#pragma warning disable SN0001
     internal class PortablePdbReader : IDisposable
     {
         private readonly Dictionary<string, MetadataReaderProvider> _cache =
@@ -145,4 +147,5 @@ namespace System.Diagnostics.Internal
             _cache.Clear();
         }
     }
+#pragma warning restore SN0001
 }


### PR DESCRIPTION
Related to [#3643](https://github.com/getsentry/sentry-dotnet/issues/3643)

Disables the custom analyzer check