### PR TITLE
Make trim warnings more specific

### DIFF
--- a/src/Ben.Demystifier/Constants.cs
+++ b/src/Ben.Demystifier/Constants.cs
@@ -4,4 +4,6 @@ internal static class Constants
 {
     internal const string TrimWarning = "This class should be avoided when compiling for AOT.";
     internal const string SuppressionResurfaced = "Surfaced by parent class";
+    internal const string AvoidAtRuntime = "Non-trimmable code is avoided at runtime";
+    internal const string SingleFileFallback = "Fallback functionality for single files";
 }

--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -19,14 +19,12 @@ using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode(Constants.TrimWarning)]
-#endif
     internal partial class EnhancedStackTrace
     {
         private static readonly Type? StackTraceHiddenAttributeType = Type.GetType("System.Diagnostics.StackTraceHiddenAttribute", false);
         private static readonly Type? AsyncIteratorStateMachineAttributeType = Type.GetType("System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute", false);
 
+        [UnconditionalSuppressMessage("Trimming", "IL2026: RequiresUnreferencedCode", Justification = Constants.AvoidAtRuntime)]
         static EnhancedStackTrace()
         {
             if (AsyncIteratorStateMachineAttributeType != null) return;
@@ -35,15 +33,18 @@ namespace System.Diagnostics
             try
             {
                 mba = Assembly.Load("Microsoft.Bcl.AsyncInterfaces");
+                AsyncIteratorStateMachineAttributeType = mba.GetType("System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute", false);
             }
             catch
             {
                 return;
             }
 
-            AsyncIteratorStateMachineAttributeType = mba.GetType("System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute", false);
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         private static List<EnhancedStackFrame> GetFrames(Exception exception)
         {
             if (exception == null)
@@ -57,6 +58,9 @@ namespace System.Diagnostics
             return GetFrames(stackTrace);
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public static List<EnhancedStackFrame> GetFrames(StackTrace stackTrace)
         {
             var frames = new List<EnhancedStackFrame>();
@@ -124,6 +128,9 @@ namespace System.Diagnostics
             return frames;
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public static ResolvedMethod GetMethodDisplayString(MethodBase originMethod)
         {
             var method = originMethod;
@@ -300,6 +307,9 @@ namespace System.Diagnostics
             return false;
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         private static bool TryResolveGeneratedName(ref MethodBase method, out Type? type, out string methodName, out string? subMethodName, out GeneratedNameKind kind, out int? ordinal)
         {
             kind = GeneratedNameKind.None;
@@ -386,6 +396,9 @@ namespace System.Diagnostics
             return false;
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         private static bool TryResolveSourceMethod(IEnumerable<MethodBase> candidateMethods, GeneratedNameKind kind, string? matchHint, ref MethodBase method, ref Type? type, out int? ordinal)
         {
             ordinal = null;
@@ -455,6 +468,9 @@ namespace System.Diagnostics
             return false;
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         private static void GetOrdinal(MethodBase method, ref int? ordinal)
         {
             var lamdaStart = method.Name.IndexOf((char)GeneratedNameKind.LambdaMethod + "__") + 3;
@@ -610,6 +626,9 @@ namespace System.Diagnostics
             return string.Empty;
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         private static ResolvedParameter GetParameter(ParameterInfo parameter)
         {
             var prefix = GetPrefix(parameter);
@@ -648,6 +667,9 @@ namespace System.Diagnostics
             };
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         private static ResolvedParameter GetValueTupleParameter(IList<string?> tupleNames, string prefix, string? name, Type parameterType)
         {
             return new ValueTupleResolvedParameter(parameterType, tupleNames)
@@ -867,6 +889,9 @@ namespace System.Diagnostics
             return false;
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         // https://github.com/dotnet/runtime/blob/c985bdcec2a9190e733bcada413a193d5ff60c0d/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs#L375-L430
         private static bool TryResolveStateMachineMethod(ref MethodBase method, out Type declaringType)
         {

--- a/src/Ben.Demystifier/EnhancedStackTrace.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.cs
@@ -6,11 +6,15 @@ using System.Collections.Generic;
 using System.Collections.Generic.Enumerable;
 using System.IO;
 using System.Text;
+using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
     internal partial class EnhancedStackTrace : StackTrace, IEnumerable<EnhancedStackFrame>
     {
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public static EnhancedStackTrace Current() => new EnhancedStackTrace(new StackTrace(1 /* skip this one frame */, true));
 
         private readonly List<EnhancedStackFrame> _frames;
@@ -26,6 +30,9 @@ namespace System.Diagnostics
         // Exceptions:
         //   T:System.ArgumentNullException:
         //     The parameter e is null.
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public EnhancedStackTrace(Exception e)
         {
             if (e == null)
@@ -36,7 +43,9 @@ namespace System.Diagnostics
             _frames = GetFrames(e);
         }
 
-
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public EnhancedStackTrace(StackTrace stackTrace)
         {
             if (stackTrace == null)

--- a/src/Ben.Demystifier/ExceptionExtensions.cs
+++ b/src/Ben.Demystifier/ExceptionExtensions.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic.Enumerable;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
-using Ben.Demystifier;
+using Constants = Ben.Demystifier.Constants;
 
 namespace System.Diagnostics
 {
@@ -23,9 +23,9 @@ namespace System.Diagnostics
         /// <summary>
         /// Demystifies the given <paramref name="exception"/> and tracks the original stack traces for the whole exception tree.
         /// </summary>
-        #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = Constants.SuppressionResurfaced)]
-        #endif
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public static T Demystify<T>(this T exception) where T : Exception
         {
             try

--- a/src/Ben.Demystifier/Internal/ILReader.cs
+++ b/src/Ben.Demystifier/Internal/ILReader.cs
@@ -5,9 +5,6 @@ using Ben.Demystifier;
 
 namespace System.Diagnostics.Internal
 {
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode(Constants.TrimWarning)]
-#endif
     internal class ILReader
     {
         private static OpCode[] singleByteOpCode;
@@ -16,13 +13,15 @@ namespace System.Diagnostics.Internal
         private readonly byte[] _cil;
         private int ptr;
 
-
         public ILReader(byte[] cil) => _cil = cil;
 
         public OpCode OpCode { get; private set; }
         public int MetadataToken { get; private set; }
         public MemberInfo? Operand { get; private set; }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public bool Read(MethodBase methodInfo)
         {
             if (ptr < _cil.Length)
@@ -43,6 +42,9 @@ namespace System.Diagnostics.Internal
                 return doubleByteOpCode[ReadByte()];
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         MemberInfo? ReadOperand(OpCode code, MethodBase methodInfo)
         {
             MetadataToken = 0;

--- a/src/Ben.Demystifier/Internal/PortablePdbReader.cs
+++ b/src/Ben.Demystifier/Internal/PortablePdbReader.cs
@@ -24,7 +24,7 @@ namespace System.Diagnostics.Internal
             new Dictionary<string, MetadataReaderProvider>(StringComparer.Ordinal);
 
 #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = Constants.SuppressionResurfaced)]
+        [UnconditionalSuppressMessage("SingleFile", "IL3000: Avoid accessing Assembly file path", Justification = Constants.SingleFileFallback)]
 #endif
         public void PopulateStackFrame(StackFrame frameInfo, MethodBase method, int IlOffset, out string fileName, out int row, out int column)
         {

--- a/src/Ben.Demystifier/ResolvedParameter.cs
+++ b/src/Ben.Demystifier/ResolvedParameter.cs
@@ -27,13 +27,13 @@ namespace System.Diagnostics
         public override string ToString() => Append(new StringBuilder()).ToString();
 
 #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
+        [UnconditionalSuppressMessage("SingleFile", "IL3002: calling members marked with 'RequiresAssemblyFilesAttribute'", Justification = Constants.SingleFileFallback)]
 #endif
         public StringBuilder Append(StringBuilder sb)
         {
             if (ResolvedType.Assembly.ManifestModule.Name == "FSharp.Core.dll" && ResolvedType.Name == "Unit")
                 return sb;
-            
+
             if (!string.IsNullOrEmpty(Prefix))
             {
                 sb.Append(Prefix)
@@ -62,7 +62,7 @@ namespace System.Diagnostics
             return sb;
         }
 
-        protected virtual void AppendTypeName(StringBuilder sb) 
+        protected virtual void AppendTypeName(StringBuilder sb)
         {
             sb.AppendTypeDisplayName(ResolvedType, fullName: false, includeGenericParameterNames: true);
         }

--- a/src/Ben.Demystifier/TypeNameHelper.cs
+++ b/src/Ben.Demystifier/TypeNameHelper.cs
@@ -9,9 +9,6 @@ using Ben.Demystifier;
 namespace System.Diagnostics
 {
     // Adapted from https://github.com/aspnet/Common/blob/dev/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode(Constants.TrimWarning)]
-#endif
     internal static class TypeNameHelper
     {
         public static readonly Dictionary<Type, string> BuiltInTypeNames = new Dictionary<Type, string>
@@ -79,7 +76,7 @@ namespace System.Diagnostics
         }
 
 #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
+        [UnconditionalSuppressMessage("SingleFile", "IL3002: calling members marked with 'RequiresAssemblyFilesAttribute'", Justification = Constants.SingleFileFallback)]
 #endif
         private static void ProcessType(StringBuilder builder, Type type, DisplayNameOptions options)
         {
@@ -154,7 +151,7 @@ namespace System.Diagnostics
         }
 
 #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
+        [UnconditionalSuppressMessage("SingleFile", "IL3002: calling members marked with 'RequiresAssemblyFilesAttribute'", Justification = Constants.SingleFileFallback)]
 #endif
         private static void ProcessGenericType(StringBuilder builder, Type type, Type[] genericArguments, int length, DisplayNameOptions options)
         {


### PR DESCRIPTION
Previously the RequiresUnreferencedCodeAttribute was often applied to entire classes rather than the specific methods that required unreferenced code... which made it difficult to create runtime workarounds.